### PR TITLE
Add functional-doc to build-deps

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -17,4 +17,5 @@
   '("at-exp-lib"
     "racket-doc"
     "lens-doc"
+    "functional-doc"
     "rackunit-lib"))


### PR DESCRIPTION
Raco setup says that this package is missing a build dependency on functional-doc.
