### PR TITLE
only depend on lens/common

### DIFF
--- a/collection/lens.rkt
+++ b/collection/lens.rkt
@@ -1,7 +1,7 @@
 #lang curly-fn at-exp racket/base
 
 (require data/collection
-         (except-in lens first-lens)
+         lens/common
          racket/contract
          scribble/srcdoc
          (for-doc racket/base
@@ -99,7 +99,7 @@
   (subsequence*-lens start (- end start)))
 
 (module+ test
-  (require rackunit (only-in lens lens-transform))
+  (require rackunit (only-in lens/common lens-transform))
   (test-case
    "ref-lens"
    (check-equal? (lens-transform (ref-lens 'key) (hash 'key 2) #{* 10})

--- a/collection/lens/private/sandbox.rkt
+++ b/collection/lens/private/sandbox.rkt
@@ -9,7 +9,7 @@
   (make-eval-factory
    #:lang 'racket
    '(data/collection
-     lens
+     lens/common
      data/collection/lens)))
 
 (define-syntax-rule (lens:interaction . body)

--- a/info.rkt
+++ b/info.rkt
@@ -11,9 +11,10 @@
   '("base"
     "collections"
     "curly-fn"
-    "lens"
+    "lens-common"
     "scribble-lib"))
 (define build-deps
   '("at-exp-lib"
     "racket-doc"
+    "lens-doc"
     "rackunit-lib"))


### PR DESCRIPTION
Since `data/collections/lens` defines its own set of lenses for its own data structures, it only needs to depend on the non-data-specific lens functions.
